### PR TITLE
Ensure that the analysis type matches the one in the scoped key.

### DIFF
--- a/lib/keen-proxy.js
+++ b/lib/keen-proxy.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var express = require('express');
 var logfmt = require('logfmt');
 var http = require('http');
+var path = require('path');
 var querystring = require('querystring');
 var Keen = require('keen.io');
 var winston = require('winston');
@@ -61,6 +62,13 @@ var KeenProxy = function(config) {
 
       // If we succesfully recognized the scope key, let's do some checks and then
       // pass this on to Keen.io
+
+      // Ensure that the analysisType that was specified in the scoped key
+      // is the same one being used in the URL.
+      if (path.basename(req.path) !== scopedParams.analysisType) {
+        self.logger.warn("Invalid type of analysis attempted. Rejecting request.");
+        return res.send(403);
+      }
 
       // Prepare a new scoped key for Keen.io - We keep all the params in there, maybe
       // some day soon Keen.io will support filtering on them too.


### PR DESCRIPTION
The cache server now checks that the analysis type specified in the Keen API path matches the one set by the scoped key.
