### PR TITLE
Allow for queries with filters that subset the scoped key.

### DIFF
--- a/keen-proxy.js
+++ b/keen-proxy.js
@@ -19,7 +19,7 @@ var config = {
 
   // Define the levels of log you want
   // silly, verbose, info, http, warn, error, silent
-  logLevel: process.env.LOG_LEVEL || 'info'
+  logLevel: process.env.LOG_LEVEL || 'info',
 
   // Toggle logging of incoming requests.
   logRequests: true

--- a/keen-proxy.js
+++ b/keen-proxy.js
@@ -20,6 +20,9 @@ var config = {
   // Define the levels of log you want
   // silly, verbose, info, http, warn, error, silent
   logLevel: process.env.LOG_LEVEL || 'info'
+
+  // Toggle logging of incoming requests.
+  logRequests: true
 };
 
 var port = Number(process.env.PORT || 5000);

--- a/lib/keen-proxy.js
+++ b/lib/keen-proxy.js
@@ -118,7 +118,12 @@ var KeenProxy = function(config) {
           }
         });
         // Add in all the filters from the scoped key that weren't in the request.
-        _.extend(filters, _.omit(scopedParams.filters, _.keys(filters)));
+        var remainingFilters = _.reject(scopedParams.filters, function (filter) {
+          return _.findWhere(filters, { property_name: filter.property_name });
+        });
+        remainingFilters.forEach(function (filter) {
+          filters.push(filter);
+        });
         // Ådd the stringified version of these sanitised filters to the query.
         req.query.filters = JSON.stringify(filters);
       }

--- a/lib/keen-proxy.js
+++ b/lib/keen-proxy.js
@@ -67,12 +67,52 @@ var KeenProxy = function(config) {
       var privateScopedKey = Keen.encryptScopedKey(config.masterKey, scopedParams);
       req.query.api_key = privateScopedKey;
 
-      // Overwrite the query parameters with the one set in the scopedKey
-      _.extend(req.query, scopedParams);
+      // Overwrite the non-filter query parameters with the one set in the scopedKey.
+      _.extend(req.query, _.omit(scopedParams, 'filters'));
 
-      // If overwriting filters, rewrite them a-la-mode Keen.io
+      // Build the filter parameter using the ones from the query, but ensuring
+      // that they match the ones established in the scoped key.
+      // This allows, for example, the scoped key to be created across multiple
+      // application IDs, but the request to be for a specific ID.
       if (_.has(scopedParams, 'filters')) {
-        req.query.filters = JSON.stringify(req.query.filters);
+        // Get a list of all of the filters in the query that are allowed
+        // based on those in the scoped key.
+        var filters = _.filter(JSON.parse(req.query.filters), function (filter) {
+          // Find the matching filter from the scoped key paramters.
+          var scopedFilter = _.findWhere(scopedParams.filters, {
+            property_name: filter.property_name
+          });
+          // If there isn't a matching scoped key filter, don't use this filter.
+          if (! scopedFilter) {
+            return false;
+          }
+          // If the scoped filter was using the "in" operator, this is a special case.
+          if (scopedFilter.operator === 'in') {
+            // If the request filter is for a specific item,
+            // look it up in the scoped filter list.
+            if (filter.operator === 'eq') {
+              return _.contains(scopedFilter.property_value, filter.property_value);
+            }
+            // If the request filter is for a group of items,
+            // ensure they are all in the scoped filter list.
+            else if (filter.operator === 'in') {
+              return _.every(filter.property_value, function (value) {
+                return _.contains(scopedFilter.property_value, value);
+              });
+            }
+            // Currently only allowing "in" and "eq" query filters to be used
+            // on top of an "eq" scoped filter. Reject all others.
+            return false;
+          }
+          else {
+            // With all other scoped filter operators, check that the operator and value match.
+            return scopedFilter.operator === filter.operator && scopedFilter.property_value === filter.property_value;
+          }
+        });
+        // Add in all the filters from the scoped key that weren't in the request.
+        _.extend(filters, _.omit(scopedParams.filters, _.keys(filters)));
+        // Ådd the stringified version of these sanitised filters to the query.
+        req.query.filters = JSON.stringify(filters);
       }
 
       // Rewrite the URL with the new query parameters

--- a/lib/keen-proxy.js
+++ b/lib/keen-proxy.js
@@ -160,7 +160,9 @@ var KeenProxy = function(config) {
     var app = express();
 
     app.configure(function() {
-      app.use(logfmt.requestLogger());
+      if (config.logRequests) {
+        app.use(logfmt.requestLogger());
+      }
       app.use(allowCrossDomain);
       app.use(enforceScopedKey);
       app.use(cacheLookup);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keen-proxy",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "A proxy to cache and limit authorized requests to Keen.io",
   "main": "proxy.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keen-proxy",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "A proxy to cache and limit authorized requests to Keen.io",
   "main": "proxy.js",
   "repository": {
@@ -19,5 +19,19 @@
     "mongodb": "~1.3.23",
     "keen.io": "0.0.4",
     "winston": "~0.7.2"
+  },
+  "devDependencies": {
+    "mocha": "~1.20.1",
+    "should": "~4.0.4",
+    "supertest": "~0.13.0",
+    "superagent": "~0.18.0",
+    "request": "~2.36.0",
+    "nock": "~0.34.1"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
   "devDependencies": {
     "mocha": "~1.20.1",
     "should": "~4.0.4",
-    "supertest": "~0.13.0",
-    "superagent": "~0.18.0",
-    "request": "~2.36.0",
-    "nock": "~0.34.1"
+    "request": "~2.36.0"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keen-proxy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A proxy to cache and limit authorized requests to Keen.io",
   "main": "proxy.js",
   "repository": {
@@ -29,6 +29,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "start": "node keen-proxy.js"
   }
 }

--- a/test/fake-keen.js
+++ b/test/fake-keen.js
@@ -1,0 +1,45 @@
+var express = require('express');
+
+var FakeKeen = (function () {
+
+  var app = null;
+  var requests = [];
+  var nextResponse = null;
+
+  return {
+    start: start,
+    getLastRequest: getLastRequest,
+    setNextResponse: setNextResponse,
+    clear: clear
+  };
+
+  function start(port) {
+    app = express();
+    app.configure(function () {
+      app.use(handleRequest);
+    });
+    app.listen(port);
+  }
+
+  function getLastRequest() {
+    return requests.pop();
+  }
+
+  function handleRequest(req, res) {
+    requests.push(req);
+    res.json(200, nextResponse);
+    nextResponse = null;
+  }
+
+  function setNextResponse(response) {
+    nextResponse = response;
+  }
+
+  function clear() {
+    nextResponse = null;
+    requests = [];
+  }
+
+}());
+
+module.exports = FakeKeen;

--- a/test/keen-proxy.js
+++ b/test/keen-proxy.js
@@ -403,7 +403,7 @@ describe('KeenProxy', function () {
 
       });
 
-    })
+    });
 
   });
 

--- a/test/keen-proxy.js
+++ b/test/keen-proxy.js
@@ -1,0 +1,172 @@
+var should = require('should');
+var Keen = require('keen.io');
+var request = require('request');
+var querystring = require('querystring');
+var MongoClient = require('mongodb').MongoClient;
+
+var KeenProxy = require('../lib/keen-proxy');
+var FakeKeen = require('./fake-keen');
+
+describe('KeenProxy', function () {
+
+  var config = {
+    mongoUri: 'mongodb://localhost/keen-cache-test',
+    keen_server: 'http://localhost:5001',
+    allowedDomains: [ 'http://localhost' ],
+    masterKey: require('crypto').randomBytes(16).toString('hex'),
+    publicKey: require('crypto').randomBytes(16).toString('hex'),
+    logLevel: 'NONE',
+    logRequests: false
+  };
+
+  var cacheBase = 'http://localhost:5000';
+
+  var keenProxy = null;
+  var keenServer = null;
+
+  before(function (done) {
+    keenProxy = new KeenProxy(config);
+    keenProxy.run(5000);
+    setTimeout(function () {
+      done();
+    }, 1000);
+  });
+
+  before(function (done) {
+    FakeKeen.start(5001);
+    done();
+  });
+
+  before(function (done) {
+    MongoClient.connect(config.mongoUri, function (err, db) {
+      db.collection('cache', function (err, collection) {
+        collection.drop(function(err, reply) {
+          db.close();
+          done();
+        });
+      });
+    });
+  });
+
+  beforeEach(function (done) {
+    done();
+    FakeKeen.clear();
+  });
+
+  describe('Enforces cross domain requests', function (done) {
+
+    it('should prevent requests from a non-supported domain', function (done) {
+
+      var headers = { Origin: 'BAD DOMAIN' };
+
+      request({ url: cacheBase, headers: headers }, function (err, res, body) {
+        res.statusCode.should.equal(403);
+        done();
+      });
+
+    });
+
+    it('should prevent requests without an origin set', function (done) {
+
+      request({ url: cacheBase }, function (err, res, body) {
+        res.statusCode.should.equal(403);
+        done();
+      });
+
+    });
+
+    it('should send an success response on OPTIONS request with valid domain', function (done) {
+
+      var headers = { Origin: config.allowedDomains[0] };
+
+      request({ url: cacheBase, headers: headers, method: 'OPTIONS' }, function (err, res, body) {
+        res.statusCode.should.equal(200);
+        body.should.equal('OK');
+        done();
+      });
+
+    });
+
+    it('should allow requests coming from valid domain', function (done) {
+
+      var headers = { Origin: config.allowedDomains[0] };
+      var scopedKey = Keen.encryptScopedKey(config.publicKey, {
+        allowed_operations: [ 'read' ]
+      });
+      var qs = querystring.stringify({ api_key: scopedKey });
+      var url = cacheBase + '/3.0/projects/PROJECT_ID/?' + qs;
+
+      request({ url: url, headers: headers }, function (err, res, body) {
+        res.statusCode.should.equal(200);
+        done();
+      });
+
+    });
+
+  });
+
+
+  describe('Validates incoming requests against scoped key', function (done) {
+
+    it('should respond with an error with an invalid scoped key', function (done) {
+
+      var headers = { Origin: config.allowedDomains[0] };
+      var scopedKey = 'BUTTS';
+      var qs = querystring.stringify({ api_key: scopedKey });
+      var url = cacheBase + '/3.0/projects/PROJECT_ID/?' + qs;
+
+      request({ url: url, headers: headers }, function (err, res, body) {
+        res.statusCode.should.equal(403);
+        done();
+      });
+
+    });
+
+    it('should respond with an error if the keys don\'t match', function (done) {
+
+      var headers = { Origin: config.allowedDomains[0] };
+      var badKey = require('crypto').randomBytes(16).toString('hex');
+      badKey.should.not.equal(config.publicKey);
+      var scopedKey = Keen.encryptScopedKey(badKey, {
+        allowed_operations: [ 'read' ]
+      });
+      var qs = querystring.stringify({ api_key: scopedKey });
+      var url = cacheBase + '/3.0/projects/PROJECT_ID/?' + qs;
+
+      request({ url: url, headers: headers }, function (err, res, body) {
+        res.statusCode.should.equal(403);
+        done();
+      });
+
+    });
+
+    it('should overwrite the request filters with those in the key', function (done) {
+
+      var headers = { Origin: config.allowedDomains[0] };
+      var keyFilters = [{
+        foo: 'bar'
+      }];
+      var requestFilters = [{
+        bar: 'foo'
+      }];
+      var scopedKey = Keen.encryptScopedKey(config.publicKey, {
+        allowed_operations: [ 'read' ],
+        filters: keyFilters
+      });
+      var qs = querystring.stringify({ api_key: scopedKey, filters: requestFilters });
+      var url = cacheBase + '/3.0/projects/PROJECT_ID/?' + qs;
+
+      request({ url: url, headers: headers }, function (err, res, body) {
+        res.statusCode.should.equal(200);
+        var req = FakeKeen.getLastRequest();
+        var filters = JSON.parse(req.query.filters);
+        filters.should.eql(keyFilters);
+        filters.should.not.eql(requestFilters);
+        done();
+      });
+
+    });
+
+  });
+
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--require should
+--reporter spec
+--ui bdd

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
 --require should
 --reporter spec
 --ui bdd
+--bail


### PR DESCRIPTION
Modify the scoped key enforcement logic to allow for filters in the
query that are subsets of those in the scoped key.

For example, you can now create a scoped key for multiple applications
and then do a request for a single application.
